### PR TITLE
Supprime les créneaux placeholders du jeudi

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,10 +219,8 @@
                         rooms: {
                             'S9 PRIO / EPS': [
                                 { label: 'Matin', time: '08h00 - 13h30', teacher: 'FALL B.', detail: 'Spécialité N°1', highlight: true, type: 'specialite' },
-                                { label: 'Après-midi', time: null }
                             ],
                             'S10': [
-                                { label: 'Matin', time: null },
                                 { label: 'Après-midi', time: '14h05 - 18h05', teacher: 'MBOUP N.', detail: 'EAF', highlight: true, type: 'eaf' }
                             ],
                             'S12': [


### PR DESCRIPTION
## Summary
- retire le créneau après-midi sans horaire de la salle S9 PRIO / EPS pour le jeudi 11/12
- enlève le bloc matin vide de la salle S10 le même jour

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dadfda32a8833194f2c9708cb68b41