### PR TITLE
Corriger l’alignement des créneaux uniques dans la vue salle

### DIFF
--- a/index.html
+++ b/index.html
@@ -512,12 +512,13 @@
                 if (!sessions.length) {
                     return '<td class="px-6 py-4 text-center"></td>';
                 }
-                const containerClasses = sessions.length > 1
-                    ? 'flex flex-col items-stretch gap-3'
-                    : 'flex items-center justify-center';
+                const containerClasses = ['flex', 'flex-col', 'items-stretch'];
+                if (sessions.length > 1) {
+                    containerClasses.push('gap-3');
+                }
                 return `
                     <td class="px-6 py-4 text-center align-top">
-                        <div class="${containerClasses}">
+                        <div class="${containerClasses.join(' ')}">
                             ${renderList(sessions, renderSessionCard)}
                         </div>
                     </td>


### PR DESCRIPTION
## Summary
- afficher les créneaux de surveillance uniques en haut des cellules du planning par salle pour éviter les confusions matin/après-midi

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dae1c03a108331ad1c227bf5150d39