### PR TITLE
Aligner la présence de Mboup sur le jeudi après-midi

### DIFF
--- a/src/lib/dashboard-data.ts
+++ b/src/lib/dashboard-data.ts
@@ -393,7 +393,6 @@ export const roomSchedule: RoomScheduleDay[] = [
           time: "14h05 - 18h05",
           teacher: "MBOUP N.",
           detail: "EAF",
-          highlight: true,
           type: "eaf",
         },
       ],


### PR DESCRIPTION
## Summary
- supprime l'indicateur de surbrillance pour la mission de Mboup le jeudi après-midi afin qu'elle reste alignée sur la plage horaire correspondante sans cercle jaune

## Testing
- npm run build *(échoue : commande `vite` introuvable dans l'environnement)*

------
https://chatgpt.com/codex/tasks/task_e_68daeeab1158833198e7ad56794e3488